### PR TITLE
docs: rewrite README for contributor focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,69 @@
 # Prism
 
-A plural system management app built with Flutter. Track who's fronting, chat between
-headmates, build habits together, and sync everything across devices with end-to-end
-encryption.
+Hi. This is the source for the Prism app — a plural system management app built
+by a plural system that uses it every day. If you're here to use Prism instead
+of hack on it, [prism.plural](https://prism.plural) is the place to go.
 
-Built by a plural system, for plural systems.
+The app is Flutter. The sync engine is Rust, lives in
+[prism-sync](https://github.com/prismplural/prism-sync), and is wired in over
+`flutter_rust_bridge`. Most of what's interesting in this codebase happens
+either at that boundary or in the design system.
 
-## What It Does
+## What's in here
 
-- **Fronting** — quick-switch who's in front, co-fronting, session history, gap detection
-- **Chat** — conversations between headmates with reactions, GIFs, voice notes, and @mentions
-- **Members** — profiles with avatars, pronouns, emoji, custom colors, and custom fields
-- **Habits** — shared habit tracking with streaks and daily check-ins
-- **Polls** — anonymous or open voting with expiration
-- **Sleep** — sleep/wake tracking integrated into the fronting timeline
-- **Notes** — per-member or shared notes with inline markdown
-- **Analytics** — fronting stats, activity charts, and co-fronting patterns
-- **Encrypted Sync** — end-to-end encrypted CRDT sync across devices via a self-hosted relay
-- **Simply Plural Import** — migrate your data from SP exports or the SP API
-- **PluralKit Sync** — bidirectional sync with PluralKit via their API
+A Flutter app targeting iOS, Android, macOS, and web. Riverpod for state (hand
+written — no `@riverpod` codegen), `go_router` with a `StatefulShellRoute` for
+navigation, Drift + SQLite for the local database, and Material 3 with
+`dynamic_color` for theming. Dart SDK `^3.11.1`. The package name is
+`prism_plurality` because the `prism` name was taken on pub.dev.
 
-Everything is local-first. Sync is optional, self-hosted, and end-to-end encrypted — the
-relay server stores only encrypted blobs and never sees your data.
+```
+lib/
+├── main.dart                  # Rust init, keychain guard, workmanager
+├── app.dart                   # MaterialApp.router with DynamicColorBuilder
+├── core/                      # Infrastructure
+│   ├── database/              # Drift DB, DAOs, tables, providers
+│   ├── router/                # go_router config (5-tab StatefulShellRoute)
+│   ├── services/              # Secure storage, notifications, validation
+│   ├── sync/                  # Dart-side sync integration with prism-sync
+│   ├── crypto/                # Dart crypto helpers
+│   └── sharing/               # Friend links, permission-scoped sharing
+├── domain/                    # Pure Dart models + abstract repositories
+├── data/                      # Repository implementations + DB ↔ model mappers
+├── features/                  # Feature modules
+├── shared/                    # Design system: theme, widgets, extensions
+└── l10n/                      # Localization
 
-## Screenshots
+test/                          # Unit, widget, and integration tests
+integration_test/              # Flutter integration tests
+android/  ios/  macos/         # Platform shells
+fastlane/  packaging/  scripts/  # Release plumbing
+```
 
-<!-- TODO: add screenshots -->
+Each feature module under `lib/features/` has the same shape: `providers/`,
+`views/`, `widgets/`, sometimes `services/` and `models/`.
 
-## Getting Started
+## How data flows
 
-### Requirements
+```
+Drift tables → DAOs → Repositories → Mappers → Freezed models → Riverpod → Widgets
+```
 
-- Flutter SDK (Dart `^3.11.1`)
-- Rust toolchain (for the sync engine)
+Synced entities go through repositories that emit CRDT ops into `pending_ops`
+via the Rust engine. **Writing directly to a synced Drift table produces a row
+that never reaches other devices.** Always go through the repository.
 
-### Build
+To add a synced entity:
+
+1. Add it to `prismSyncSchema` in `lib/core/sync/sync_schema.dart`.
+2. Register a builder in `lib/core/sync/drift_sync_adapter.dart`.
+3. `test/core/sync/sync_schema_parity_test.dart` fails CI if those two drift apart.
+
+## Build and run
+
+You need Flutter (Dart `^3.11.1`) and the platform toolchains for whatever
+you're targeting. A Rust toolchain only matters if you're modifying
+`prism-sync` locally.
 
 ```bash
 flutter pub get
@@ -42,63 +71,88 @@ dart run build_runner build --delete-conflicting-outputs
 flutter run
 ```
 
-The sync engine is a Rust library ([prism-sync](https://github.com/prismplural/prism-sync))
-included via path dependencies. See the sync repo for build instructions if you need to
-modify the Rust side.
+`build_runner` generates `*.freezed.dart`, `*.g.dart`, and Drift database code.
+Swap `build` for `watch` while you're actively making changes.
 
-### Voice notes
+### Working against a local prism-sync checkout
 
-New voice notes use a mobile-first Ogg Opus path.
+By default `pubspec.yaml` pulls `prism_sync*` from the public git repo. To
+point at a sibling clone, drop a `pubspec_overrides.yaml` next to
+`pubspec.yaml`:
 
-- **Android** records Ogg Opus directly.
-- **iOS** records Opus in CAF, may briefly show **Preparing voice note...**, then remuxes to Ogg before upload.
-- **Playback** uses decrypted bytes in memory rather than the old `.m4a` temp-file path.
-- `pubspec.yaml` currently overrides `flutter_soloud` and `ogg_caf_converter` to local path dependencies while Prism tracks fixes in those forks.
+```yaml
+dependency_overrides:
+  prism_sync:
+    path: ../prism-sync/dart/packages/prism_sync
+  prism_sync_drift:
+    path: ../prism-sync/dart/packages/prism_sync_drift
+  prism_sync_flutter:
+    path: ../prism-sync/dart/packages/prism_sync_flutter
+```
 
-### Test
+That file is gitignored. After changing the Rust FFI surface in
+`crates/prism-sync-ffi/src/api.rs`, regenerate bindings from the sync repo:
 
 ```bash
+cd ../prism-sync
+flutter_rust_bridge_codegen generate
+```
+
+### Testing
+
+```bash
+flutter analyze
 flutter test
+flutter test test/path/to/file_test.dart
 ```
 
-680+ tests covering database operations, domain logic, sync integration, and widget behavior.
-
-## Architecture
-
-```
-lib/
-├── core/           # Database (Drift), sync integration, router, services
-├── domain/         # Pure Dart models (freezed) and repository interfaces
-├── data/           # Repository implementations and DB↔model mappers
-├── features/       # Feature modules (fronting, chat, habits, polls, ...)
-└── shared/         # Design system widgets, theme, extensions
-```
-
-| Layer | Tech |
-|-------|------|
-| UI | Flutter (Material 3, dynamic color) |
-| State | Riverpod |
-| Database | Drift + SQLite |
-| Navigation | go_router |
-| Sync | [prism-sync](https://github.com/prismplural/prism-sync) (Rust, via FFI) |
-
-## AI Disclosure
-
-Prism uses AI for development. Prism is written by a plural system that actually uses it
-every day. We use Claude extensively as a coding tool.
-
-The security architecture, design decisions, interface — the things that make this app what
-it is — are ours. The encryption is fully auditable and open source regardless of what tools
-wrote it, and we hope the app's quality stands on its own.
+In-memory Drift databases isolate DB tests.
 
 ## Contributing
 
-Contributions are welcome! Whether it's bug reports, feature ideas, or pull requests — all
-help is appreciated. For larger changes, opening an issue first helps us coordinate and
-avoid duplicated effort.
+We're glad you're here. Bug reports, accessibility issues, fixes, and feature
+ideas are all welcome — direct feedback matters a lot to us.
 
-By submitting a pull request, you agree to the [Contributor License Agreement](CLA.md).
+If you're thinking about something bigger than a polish PR, please open an
+issue first. Sync compatibility, threat model, and platform parity are the
+kinds of constraints that aren't obvious from the code, and we'd rather flag
+them at the design stage than during review.
+
+A few things worth knowing before sending a patch:
+
+- Hand-written Riverpod providers only. No `@riverpod` codegen.
+- All modal sheets go through `PrismSheet.show()`. All app bar buttons go
+  through `PrismIconButton`.
+- Always use the `secureStorage` constant from
+  `core/services/secure_storage.dart` — never bare `FlutterSecureStorage()`.
+- Accent colors come from `Theme.of(context).colorScheme.primary`, not from
+  settings reads.
+- If you regenerate code (Drift schema, freezed, JSON), commit the generated
+  files alongside the source change.
+- If you touched the sync schema, the parity test will tell you.
+
+By submitting a pull request you agree to the
+[Contributor License Agreement](CLA.md). The CLA exists so we can dual
+distribute — AGPL upstream, plus first-party builds on the App Store and
+Google Play.
+
+For security issues, please don't open a public issue. See
+[SECURITY.md](SECURITY.md).
+
+## Related repositories
+
+- [prism-sync](https://github.com/prismplural/prism-sync) — the Rust sync
+  engine, Dart FFI packages, and self-hostable relay server.
+- [prism-fronters](https://github.com/prismplural/prism-fronters) — public
+  PluralKit fronters dashboard.
+
+## On AI
+
+We use AI coding tools (local and hosted) heavily while building Prism. The
+security architecture, design decisions, and interface are ours; the
+encryption is fully auditable regardless of what tools wrote the surrounding
+code. We hope the app's quality stands on its own.
 
 ## License
 
-[GNU Affero General Public License v3.0](LICENSE)
+[GNU Affero General Public License v3.0](LICENSE).


### PR DESCRIPTION
Rewrites the public README around what contributors need:

- Personal intro that points end-users to prism.plural
- Repository layout + data flow diagram
- `pubspec_overrides.yaml` pattern for working against a sibling prism-sync checkout
- Synced-entity recipe (schema + adapter + parity test)
- Contribution conventions inline (Riverpod hand-written, `PrismSheet.show()`, `secureStorage` constant, etc.)

Drops the feature-style overview, stack tables, numbered "Suggested PR flow," and other AI-template-y scaffolding. Voice tuned to match the prism.plural About page (first-person plural, short declarative sentences).