### PR TITLE
fix(linux): pin secure storage keyring fix

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -524,8 +524,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_secure_storage_linux
-      ref: "7f1730a3403364f942a66d0833037be3dc88e540"
-      resolved-ref: "7f1730a3403364f942a66d0833037be3dc88e540"
+      ref: "2e720ff7e6b956a5d1197a5077bb8be39a5d5632"
+      resolved-ref: "2e720ff7e6b956a5d1197a5077bb8be39a5d5632"
       url: "https://github.com/prismplural/flutter_secure_storage.git"
     source: git
     version: "3.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -524,8 +524,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_secure_storage_linux
-      ref: "d19588a6dc4d58aaed85039b47d567326f00af20"
-      resolved-ref: "d19588a6dc4d58aaed85039b47d567326f00af20"
+      ref: "f7738c2da4f9eb9923849bf0810216b47361b342"
+      resolved-ref: "f7738c2da4f9eb9923849bf0810216b47361b342"
       url: "https://github.com/prismplural/flutter_secure_storage.git"
     source: git
     version: "3.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -524,8 +524,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_secure_storage_linux
-      ref: "2e720ff7e6b956a5d1197a5077bb8be39a5d5632"
-      resolved-ref: "2e720ff7e6b956a5d1197a5077bb8be39a5d5632"
+      ref: "d19588a6dc4d58aaed85039b47d567326f00af20"
+      resolved-ref: "d19588a6dc4d58aaed85039b47d567326f00af20"
       url: "https://github.com/prismplural/flutter_secure_storage.git"
     source: git
     version: "3.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -521,12 +521,13 @@ packages:
     source: hosted
     version: "0.3.2"
   flutter_secure_storage_linux:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_secure_storage_linux
-      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_secure_storage_linux
+      ref: "7f1730a3403364f942a66d0833037be3dc88e540"
+      resolved-ref: "7f1730a3403364f942a66d0833037be3dc88e540"
+      url: "https://github.com/prismplural/flutter_secure_storage.git"
+    source: git
     version: "3.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -524,8 +524,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: flutter_secure_storage_linux
-      ref: "f7738c2da4f9eb9923849bf0810216b47361b342"
-      resolved-ref: "f7738c2da4f9eb9923849bf0810216b47361b342"
+      ref: "d042536e0ef0c052e6a9351414934a80c6f2b3b5"
+      resolved-ref: "d042536e0ef0c052e6a9351414934a80c6f2b3b5"
       url: "https://github.com/prismplural/flutter_secure_storage.git"
     source: git
     version: "3.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,7 +150,7 @@ dependency_overrides:
     git:
       url: https://github.com/prismplural/flutter_secure_storage.git
       path: flutter_secure_storage_linux
-      ref: f7738c2da4f9eb9923849bf0810216b47361b342
+      ref: d042536e0ef0c052e6a9351414934a80c6f2b3b5
   permission_handler_windows:
     git:
       url: https://github.com/prismplural/flutter-permission-handler.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,7 +150,7 @@ dependency_overrides:
     git:
       url: https://github.com/prismplural/flutter_secure_storage.git
       path: flutter_secure_storage_linux
-      ref: 2e720ff7e6b956a5d1197a5077bb8be39a5d5632
+      ref: d19588a6dc4d58aaed85039b47d567326f00af20
   permission_handler_windows:
     git:
       url: https://github.com/prismplural/flutter-permission-handler.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,7 +150,7 @@ dependency_overrides:
     git:
       url: https://github.com/prismplural/flutter_secure_storage.git
       path: flutter_secure_storage_linux
-      ref: 7f1730a3403364f942a66d0833037be3dc88e540
+      ref: 2e720ff7e6b956a5d1197a5077bb8be39a5d5632
   permission_handler_windows:
     git:
       url: https://github.com/prismplural/flutter-permission-handler.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -144,6 +144,13 @@ dev_dependencies:
   drift_dev: ^2.0.0
 
 dependency_overrides:
+  # Treat a missing default Secret Service collection as an empty Linux store.
+  # Remove after https://github.com/juliansteenbakker/flutter_secure_storage/pull/1177 ships.
+  flutter_secure_storage_linux:
+    git:
+      url: https://github.com/prismplural/flutter_secure_storage.git
+      path: flutter_secure_storage_linux
+      ref: 7f1730a3403364f942a66d0833037be3dc88e540
   permission_handler_windows:
     git:
       url: https://github.com/prismplural/flutter-permission-handler.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -150,7 +150,7 @@ dependency_overrides:
     git:
       url: https://github.com/prismplural/flutter_secure_storage.git
       path: flutter_secure_storage_linux
-      ref: d19588a6dc4d58aaed85039b47d567326f00af20
+      ref: f7738c2da4f9eb9923849bf0810216b47361b342
   permission_handler_windows:
     git:
       url: https://github.com/prismplural/flutter-permission-handler.git


### PR DESCRIPTION
## Summary

- override only `flutter_secure_storage_linux` with the exact PrismPlural fork commit that handles missing Secret Service collections safely
- keep the top-level `flutter_secure_storage` 10.3.1 dependency and all non-Linux platform packages unchanged
- document when the temporary override can be removed

The plugin fix is submitted upstream as [flutter_secure_storage#1177](https://github.com/juliansteenbakker/flutter_secure_storage/pull/1177). Prism pins immutable commit `d042536e0ef0c052e6a9351414934a80c6f2b3b5`, so the build does not depend on an unmerged branch or on the separate broader Linux PR.

## Why

A Secret Service daemon may legitimately have no default collection on a fresh Linux profile. The published Linux plugin reports that state as `KeyringLocked`, sending Prism to the temporary secure-storage recovery screen before setup.

The fork treats fresh missing reads as an empty store and missing deletes as successful no-ops. It ignores and preserves unrelated secrets in other collections. If matching data exists elsewhere while the default alias is missing, it fails closed instead of masking or orphaning that data. Genuine locked collections continue to report `KeyringLocked`.

## Verification

- `flutter pub get --enforce-lockfile` resolved only `flutter_secure_storage_linux` to the exact fork SHA
- focused secure-storage, reset, recovery, and startup-guard suite: 186 tests passed; one Rust-artifact E2E test skipped as expected
- x64 Linux release build passed: `flutter build linux --release --no-tree-shake-icons`
- fork integration matrix passed for empty missing (6), nonmatching-secret (6), initialized (15), genuinely locked (6), and orphaned-data (6) states
- missing-collection fixtures preserve the full collection set and any unrelated secret
- fork Linux native tests passed (13); formatting and analysis passed
- current Arch/KWallet provider check passed all five noninteractive missing-default operations in a real Flutter Linux build and preserved the missing alias and complete collection set
- KWallet's first-write path reached its interactive collection-creation prompt; accepting that prompt and the Flatpak UI flow remain a real-desktop smoke test
- app analysis introduced no dependency errors; the branch still reports unrelated pre-existing warnings